### PR TITLE
Use CONDA_PREFIX

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -6,10 +6,9 @@ if [[ "$unamestr" == 'Darwin' ]]; then
 else
    cp $RECIPE_DIR/build_linux.conf build.conf
 fi
-sed -i -e "s:PREFIX:$PREFIX:g" build.conf
 
-export LIBRARY_PATH="${PREFIX}/lib"
-export LD_LIBRARY_PATH="${PREFIX}/lib"
+export LIBRARY_PATH="${CONDA_PREFIX}/lib"
+export LD_LIBRARY_PATH="${CONDA_PREFIX}/lib"
 
 $PYTHON setup.py build
 $PYTHON setup.py install

--- a/recipe/build_linux.conf
+++ b/recipe/build_linux.conf
@@ -1,9 +1,9 @@
 [lapack]
-library_dirs = PREFIX/lib
+library_dirs = ${CONDA_PREFIX}/lib
 libraries = openblas gfortran
-extra_link_args = -Wl,-rpath=PREFIX/lib
+extra_link_args = -Wl,-rpath=${CONDA_PREFIX}/lib
 [mumps]
-include_dirs = PREFIX/include
-library_dirs = PREFIX/lib
+include_dirs = ${CONDA_PREFIX}/include
+library_dirs = ${CONDA_PREFIX}/lib
 libraries = zmumps mumps_common pord metis esmumps scotch scotcherr mpiseq gfortran
-extra_link_args = -Wl,-rpath=PREFIX/lib
+extra_link_args = -Wl,-rpath=${CONDA_PREFIX}/lib

--- a/recipe/build_mac.conf
+++ b/recipe/build_mac.conf
@@ -1,9 +1,9 @@
 [lapack]
-library_dirs = PREFIX/lib
+library_dirs = ${CONDA_PREFIX}/lib
 libraries = openblas gfortran
-extra_link_args = -Wl,-rpath,PREFIX/lib
+extra_link_args = -Wl,-rpath,${CONDA_PREFIX}/lib
 [mumps]
-include_dirs = PREFIX/include
-library_dirs = PREFIX/lib
+include_dirs = ${CONDA_PREFIX}/include
+library_dirs = ${CONDA_PREFIX}/lib
 libraries = zmumps mumps_common pord metis esmumps scotch scotcherr mpiseq gfortran
-extra_link_args = -Wl,-rpath,PREFIX/lib
+extra_link_args = -Wl,-rpath,${CONDA_PREFIX}/lib


### PR DESCRIPTION
This will make it easier when installing kwant-dev and using these `build.conf` files without the need of using `sed`.