### PR TITLE
More informative filename

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
   version: {{ version }}
 
 source:
-  fn: v{{ version }}.tar.gz
+  fn: {{ name }}-{{ version }}.tar.gz
   url: https://gitlab.kwant-project.org/kwant/kwant/repository/archive.tar.gz?ref=v{{ version }}
   sha256: d298791b920aa5a8191a83178e85472310db678b8237eaa928a8b2a347e825d8
 


### PR DESCRIPTION
As the filename provided here does not need to match the actual filename, but instead represents the name it will be saved as, it makes more sense to have this be more informative. Typically this is done by including the package name and version.